### PR TITLE
refactor(app): Remove log fatal

### DIFF
--- a/app/getter/getter.go
+++ b/app/getter/getter.go
@@ -87,16 +87,16 @@ func genURL(stream store.Stream) string {
 func getRequest(url string) []byte {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Fatalf("Failed to make request, %s", err)
+		log.Printf("Failed to make request, %s", err)
 	}
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Fatalf("Bad response, %s", err)
+		log.Printf("Bad response, %s", err)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("Failed to read response body, %s", err)
+		log.Printf("Failed to read response body, %s", err)
 	}
 	return body
 }

--- a/app/youtubeapi/api.go
+++ b/app/youtubeapi/api.go
@@ -34,7 +34,7 @@ func (yt *YoutubeAPI) GetSearchList(options *SearchOptions) youtube.SearchListRe
 	// Executing search
 	listResponse, err := listCall.Do()
 	if err != nil {
-		log.Fatalf("Unable to get search list response: %v", err)
+		log.Printf("Unable to get search list response: %v", err)
 	}
 
 	return *listResponse
@@ -55,7 +55,7 @@ func (yt *YoutubeAPI) GetVideosList(id []string) youtube.VideoListResponse {
 	// Executing search
 	listResponse, err := listCall.Do()
 	if err != nil {
-		log.Fatalf("Unable to get video list response: %v", err)
+		log.Printf("Unable to get video list response: %v", err)
 	}
 	return *listResponse
 }


### PR DESCRIPTION
Removed log fatal from api and getter as these are methods that are expected to fail (lack of quota) and thus shouldn't shut down the whole process.